### PR TITLE
Guest dedupe (guests_set), plugin cache correctness, yt-dlp/audio/TTS fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,5 @@ DE_DOWNLOAD_URL=
 # YT_DLP_VERBOSE=1
 # Optional only when not using YT_DLP_IMPERSONATE:
 # YT_DLP_USER_AGENT=
+# Explicit Deno binary for yt-dlp EJS (otherwise PATH or ~/.deno/bin/deno)
+# YT_DLP_DENO=/Users/you/.deno/bin/deno

--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ OPENROUTER_MODEL=deepseek/deepseek-chat
 # Slow-path TTS via OpenRouter (OpenAI-compatible audio.speech); ignored when LLMFH_OPENROUTER_FREE_MODE=1 (uses gTTS)
 OPENROUTER_TTS_MODEL=openai/gpt-4o-mini-tts-2025-12-15
 OPENROUTER_TTS_VOICE=alloy
-# native = pydantic-ai NativeOutput where supported; tool = tool-calling output (better for openrouter/free)
+# native = pydantic-ai NativeOutput where supported; tool = tool-calling output (required for openrouter/free and DeepSeek on OpenRouter)
 LLMFH_STRUCTURED_OUTPUT_MODE=native
 # Retry structured call with tool output if native fails (optional)
 # LLMFH_STRUCTURED_OUTPUT_FALLBACK=1

--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,8 @@ SUPASET_KEY=
 # SUPABASE_STORAGE_BUCKET=llmfh
 
 # --- OpenRouter chat + structured output ---
-# Paid/default chat slug when LLMFH_OPENROUTER_FREE_MODE is off (DeepSeek V2 line on OpenRouter)
-OPENROUTER_MODEL=deepseek/deepseek-chat-v2.5
+# Paid/default chat slug when LLMFH_OPENROUTER_FREE_MODE is off (DeepSeek chat on OpenRouter; slug maps to current flagship)
+OPENROUTER_MODEL=deepseek/deepseek-chat
 # Slow-path TTS via OpenRouter (OpenAI-compatible audio.speech); ignored when LLMFH_OPENROUTER_FREE_MODE=1 (uses gTTS)
 OPENROUTER_TTS_MODEL=openai/gpt-4o-mini-tts-2025-12-15
 OPENROUTER_TTS_VOICE=alloy

--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,8 @@ SUPASET_KEY=
 # SUPABASE_STORAGE_BUCKET=llmfh
 
 # --- OpenRouter chat + structured output ---
-# Paid/default chat slug when LLMFH_OPENROUTER_FREE_MODE is off
-OPENROUTER_MODEL=openai/gpt-4o-mini
+# Paid/default chat slug when LLMFH_OPENROUTER_FREE_MODE is off (DeepSeek V2 line on OpenRouter)
+OPENROUTER_MODEL=deepseek/deepseek-chat-v2.5
 # Slow-path TTS via OpenRouter (OpenAI-compatible audio.speech); ignored when LLMFH_OPENROUTER_FREE_MODE=1 (uses gTTS)
 OPENROUTER_TTS_MODEL=openai/gpt-4o-mini-tts-2025-12-15
 OPENROUTER_TTS_VOICE=alloy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Ruff
-        run: uv run ruff check .
+      # Same versions as local hooks (.pre-commit-config.yaml); skip gitleaks here because the job runs gitleaks-action above (full-history scan).
+      - name: Pre-commit (ruff, pyright)
+        env:
+          SKIP: gitleaks
+        run: uv run pre-commit run --all-files
 
       - name: Mypy
         run: uv run mypy src tests
-
-      - name: Pyright
-        run: uv run pyright
 
       - name: Unit tests
         run: uv run pytest tests/test*.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# Install: uv sync --extra dev && uv run pre-commit install
+# Run manually: uv run pre-commit run --all-files
+# Hooks mirror CI (ruff, pyright) plus Gitleaks on staged changes.
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff-check
+
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.409
+    hooks:
+      - id: pyright

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See [.env.example](.env.example) and **[docs/supabase.md](docs/supabase.md)** fo
 Optional:
 
 - environment selector `LLMFH_ENV` (`prod` for production publishing)
-- `OPENROUTER_MODEL` (OpenRouter slug; default / example: `deepseek/deepseek-chat-v2.5`)
+- `OPENROUTER_MODEL` (OpenRouter slug; default / example: `deepseek/deepseek-chat`)
 - `OPENROUTER_TTS_MODEL`, `OPENROUTER_TTS_VOICE` for slow TTS
 - `LLMFH_STRUCTURED_OUTPUT_MODE=native|tool` (pydantic-ai structured output style)
 - `LLMFH_OPENROUTER_FREE_MODE=1` for zero-cost chat (`openrouter/free`; ignores paid `OPENROUTER_MODEL` from `.env`) and gTTS for slow TTS — optional `LLMFH_OPENROUTER_FREE_CHAT_MODEL` to pick another slug

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ These instructions use `uv` for local development and CI parity.
 
 - Python 3.12
 - [uv](https://docs.astral.sh/uv/)
+- **Deno** (for yt-dlp YouTube JS / “n challenge” solving — unrelated to cookies). Install with `curl -fsSL https://deno.land/install.sh | sh` or your package manager; the installer places `~/.deno/bin/deno`. ShowRunner passes this path to yt-dlp when present (or use `deno` on `PATH`, or set `YT_DLP_DENO`). CI uses [denoland/setup-deno](https://github.com/denoland/setup-deno).
 - **macOS:** [Miniconda](https://docs.conda.io/en/latest/miniconda.html) / [Mambaforge](https://github.com/conda-forge/miniforge) for ffmpeg (see below)
 - **Linux CI:** ffmpeg comes from the Ubuntu 24.04 archive (pinned in-repo; see [.github/ffmpeg-deb.pin](.github/ffmpeg-deb.pin))
 
@@ -63,6 +64,12 @@ For a **non-prod** dry run where Podbean publish is skipped by config, you can o
 
 ```bash
 uv run python scripts/preflight_env.py --strict --require-ffmpeg --skip-podbean
+```
+
+Include `--require-deno` if you want preflight to fail when Deno is missing (recommended before release-style runs):
+
+```bash
+uv run python scripts/preflight_env.py --strict --require-ffmpeg --require-deno --skip-podbean
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See [.env.example](.env.example) and **[docs/supabase.md](docs/supabase.md)** fo
 Optional:
 
 - environment selector `LLMFH_ENV` (`prod` for production publishing)
-- `OPENROUTER_MODEL` (OpenRouter slug, e.g. `openai/gpt-4o-mini`)
+- `OPENROUTER_MODEL` (OpenRouter slug; default / example: `deepseek/deepseek-chat-v2.5`)
 - `OPENROUTER_TTS_MODEL`, `OPENROUTER_TTS_VOICE` for slow TTS
 - `LLMFH_STRUCTURED_OUTPUT_MODE=native|tool` (pydantic-ai structured output style)
 - `LLMFH_OPENROUTER_FREE_MODE=1` for zero-cost chat (`openrouter/free`; ignores paid `OPENROUTER_MODEL` from `.env`) and gTTS for slow TTS — optional `LLMFH_OPENROUTER_FREE_CHAT_MODEL` to pick another slug

--- a/configs/configv3.yaml
+++ b/configs/configv3.yaml
@@ -4,7 +4,8 @@ plugins:
   - name: guest_selection
     plugin: guestSelection
     class: GuestSelection
-    cache: True
+    # Always dequeue from Supabase; caching replayed the same lineup forever without --clear-cache.
+    cache: False
     params:
       !include includes/guest_selection.yml
 
@@ -17,16 +18,16 @@ plugins:
       guests_parameter: guest_selection_guests
       system_message: >
         You are a big shot new york live show producer, writer, and performer. 
-        You are current the show runner for the Live From Here show and are calling all the shots. 
+        You are current the show runner for the Live From There show and are calling all the shots. 
         You are very emotional and nostalgic and like to listen to music, podcasts, npr, and long-form improv comedy.
 
       script_prompt: >
-        Write a script for the intro to be read Verbatim by Chris Thile.  
-        Chris should announce these guests: {{ guests }}.
-        This intro segment should be about 5 minutes long and end with Chris announcing the guests.  
+        Write a script for the intro to be read Verbatim by Dris Tahiti.  
+        Dris should announce these guests: {{ guests }}.
+        This intro segment should be about 5 minutes long and end with Dris announcing the guests.  
         Applause breaks and duration should be added and denoted with [APPLAUSE duration x] where x is in seconds and could be between 3 and 6 seconds, for example:
           [APPLAUSE 5 seconds]
-        A musical background will be played by Chris and the band underneath his introduction, this should be described and denoted in the script with [BACKGROUND MUSIC] and should occur only once at the beginning, and with one or more of the descriptors bluegrass, folk, country, rock, jazz, classical, post-rock. For example :
+        A musical background will be played by Dris and the band underneath his introduction, this should be described and denoted in the script with [BACKGROUND MUSIC] and should occur only once at the beginning, and with one or more of the descriptors bluegrass, folk, country, rock, jazz, classical, post-rock. For example :
           [BACKGROUND MUSIC: bluegrass]
 
       json_script_prompt: >
@@ -35,7 +36,7 @@ plugins:
         Background music should get its own cue with speaker name Music and dialog of [MUSIC <music_type>], for example [MUSIC bluegrass].
         There should be only one music cue, and it should be first.
         Applause breaks should get their own entry with speaker name Audience and dialog of [APPLAUSE duration x], for example [APPLAUSE duration 10].
-        The only valid values for speaker are Music, Chris Thile, and Audience.
+        The only valid values for speaker are Music, Dris Thile, and Audience.
         Choose only one music cue and make it the first speaker.
         Respond with a JSON object that has a single key "lines" whose value is an array of objects,
         each object having string fields "speaker" and "dialog" only.
@@ -43,20 +44,20 @@ plugins:
       extra_prompts:
         # - name: story
         #   prompt: > 
-        #     Now generate a story for Chris to tell. The story could be about anything but feel like it's about nothing and everything. The topic should seem fairly random and non-obvious. It should be told in the first-person. The story should be at least 5 paragraphs long and last no more than 5 minutes when read aloud. It should generate some emotion in the listener of joy, regret, nostalgia, and/or elation.
-        #     It should never begin with Once upon a time. Chris should never directly mention the emotions he is trying to evoke. Avoid stories where nothing actually happens. 
+        #     Now generate a story for Dris to tell. The story could be about anything but feel like it's about nothing and everything. The topic should seem fairly random and non-obvious. It should be told in the first-person. The story should be at least 5 paragraphs long and last no more than 5 minutes when read aloud. It should generate some emotion in the listener of joy, regret, nostalgia, and/or elation.
+        #     It should never begin with Once upon a time. Dris should never directly mention the emotions he is trying to evoke. Avoid stories where nothing actually happens. 
         #     He should talk to someone, see something happen, and make something happen in each story. He should relay at least one short conversation he had.
         #     Use a lot of contractions often and as many colloquialisms as possible.
         #     You do not speak, just tell the story.
         - name: outro
           prompt: >
-            Now write an outro for Chris to read. 
+            Now write an outro for Dris to read. 
             It should be about 1 to 2 minutes long and should include a call to action for the audience to do something. 
             It should be a single paragraph and should be written in the first person.
             It should thank the guests.
             Applause breaks and duration should be added and denoted with [APPLAUSE duration x] where x is in seconds and could be between 3 and 6 seconds, for example:
               [APPLAUSE 5 seconds]
-            A musical background will be played by Chris and the band underneath his introduction, this should be described and denoted in the script with [BACKGROUND MUSIC] and should occur only once at the beginning, and with one or more of the descriptors bluegrass, folk, country, rock, jazz, classical, post-rock. For example :
+            A musical background will be played by Dris and the band underneath his introduction, this should be described and denoted in the script with [BACKGROUND MUSIC] and should occur only once at the beginning, and with one or more of the descriptors bluegrass, folk, country, rock, jazz, classical, post-rock. For example :
               [BACKGROUND MUSIC: bluegrass]
               [BACKGROUND MUSIC: post-rock]
 

--- a/configs/includes/guest_selection.yml
+++ b/configs/includes/guest_selection.yml
@@ -1,3 +1,6 @@
+# Same SupaSet as plugins.intro (`guests_set`): prune rows older than N days (0 = no pruning).
+guests_used_autoexpire_days: 365
+
 guest_categories:
   - name: music
     queue_size: 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
   "mypy",
   "pyright",
   "pip-audit",
+  "pre-commit>=4.6.0",
   "types-PyYAML",
   "types-requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "pyyaml-include<2",
   "ytmusicapi",
   "pydantic-ai>=1.88.0",
-  "curl-cffi>=0.10,<0.15",
+  "curl-cffi>=0.15,<0.16",
 ]
 
 [project.optional-dependencies]

--- a/scripts/delete_podbean_episode.py
+++ b/scripts/delete_podbean_episode.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Delete Podbean episode(s) whose title contains a substring (case-insensitive).
+
+Uses PODBEAN_CLIENT_ID / PODBEAN_CLIENT_SECRET from the environment or repo-root .env.
+
+Example:
+  uv run python scripts/delete_podbean_episode.py --match "Episode 65"
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import dotenv
+import requests
+from requests.auth import HTTPBasicAuth
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _token(client_id: str, client_secret: str, timeout: float) -> str:
+    url = "https://api.podbean.com/v1/oauth/token"
+    response = requests.post(
+        url,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={"grant_type": "client_credentials"},
+        auth=HTTPBasicAuth(client_id, client_secret),
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        sys.stderr.write(f"OAuth failed: {response.status_code} {response.text}\n")
+        sys.exit(1)
+    return response.json()["access_token"]
+
+
+def _list_episodes(access_token: str, *, limit: int, timeout: float) -> list[dict]:
+    out: list[dict] = []
+    offset = 0
+    while True:
+        url = "https://api.podbean.com/v1/episodes"
+        response = requests.get(
+            url,
+            params={
+                "access_token": access_token,
+                "offset": offset,
+                "limit": limit,
+            },
+            timeout=timeout,
+        )
+        if response.status_code != 200:
+            sys.stderr.write(f"List episodes failed: {response.status_code} {response.text}\n")
+            sys.exit(1)
+        batch = response.json().get("episodes") or []
+        out.extend(batch)
+        if len(batch) < limit:
+            break
+        offset += limit
+    return out
+
+
+def _delete_episode(access_token: str, episode_id: str, timeout: float) -> dict:
+    url = f"https://api.podbean.com/v1/episodes/{episode_id}/delete"
+    response = requests.post(
+        url,
+        data={"access_token": access_token, "delete_media_file": "yes"},
+        timeout=timeout,
+    )
+    if response.status_code != 200:
+        sys.stderr.write(f"Delete failed: {response.status_code} {response.text}\n")
+        sys.exit(1)
+    return response.json()
+
+
+def main() -> None:
+    dotenv.load_dotenv(REPO_ROOT / ".env")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--match",
+        default="Episode 65",
+        help="Case-insensitive substring to match against episode titles.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List matching episodes but do not delete.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Page size for Podbean list endpoint.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="HTTP timeout seconds.",
+    )
+    args = parser.parse_args()
+
+    client_id = os.getenv("PODBEAN_CLIENT_ID")
+    client_secret = os.getenv("PODBEAN_CLIENT_SECRET")
+    if not client_id or not client_secret:
+        sys.stderr.write("Missing PODBEAN_CLIENT_ID or PODBEAN_CLIENT_SECRET.\n")
+        sys.exit(1)
+
+    needle = args.match.lower()
+    token = _token(client_id, client_secret, args.timeout)
+    episodes = _list_episodes(token, limit=args.limit, timeout=args.timeout)
+    hits = [e for e in episodes if needle in (e.get("title") or "").lower()]
+
+    if not hits:
+        print(f"No episodes matched {args.match!r} (searched {len(episodes)} episode(s)).")
+        sys.exit(1)
+
+    for e in hits:
+        eid = e.get("id")
+        title = e.get("title")
+        print(f"{'Would delete' if args.dry_run else 'Deleting'}: id={eid} title={title!r}")
+
+    if args.dry_run:
+        return
+
+    for e in hits:
+        body = _delete_episode(token, str(e["id"]), args.timeout)
+        print(f"Deleted ok: {body}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preflight_env.py
+++ b/scripts/preflight_env.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from llm_from_here.plugins.ytfetch import _resolved_deno_executable
 from llm_from_here.supabase_env import get_supabase_service_role_key, get_supabase_url
 
 
@@ -52,6 +53,11 @@ def main() -> None:
         action="store_true",
         help="Require ffmpeg and ffprobe on PATH.",
     )
+    parser.add_argument(
+        "--require-deno",
+        action="store_true",
+        help="Require Deno for yt-dlp YouTube JS/EJS (YT_DLP_DENO, PATH, or ~/.deno/bin/deno).",
+    )
     args = parser.parse_args()
     _load_repo_dotenv()
 
@@ -70,11 +76,16 @@ def main() -> None:
             if shutil.which(bin_name) is None:
                 missing.append(bin_name)
 
+    if args.require_deno and _resolved_deno_executable() is None:
+        missing.append("deno")
+
     if missing:
         print(f"Missing or not on PATH: {', '.join(missing)}", file=sys.stderr)
         sys.exit(1 if args.strict else 0)
 
-    print("Preflight OK: required variables (and optional ffmpeg tools) are present.")
+    print(
+        "Preflight OK: required variables (and optional ffmpeg/deno checks) are present."
+    )
     sys.exit(0)
 
 

--- a/scripts/run_until_new_guests.py
+++ b/scripts/run_until_new_guests.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Run ShowRunner with --clear-cache; kill + retry if intro repeats the same guest multiset
+as the latest lineup prior to this invocation (detected via showRunner.log).
+"""
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LOG = os.path.join(REPO, "showRunner.log")
+
+
+def line_count(path: str) -> int:
+    try:
+        with open(path, "rb") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return 0
+
+
+def fingerprint_intro_guests_after(path: str, min_line: int) -> tuple[str, ...] | None:
+    latest: tuple[str, ...] | None = None
+    with open(path, encoding="utf-8", errors="replace") as f:
+        for i, line in enumerate(f, start=1):
+            if i <= min_line:
+                continue
+            if "introFromGuestlist" not in line or "Found guests:" not in line:
+                continue
+            payload = line.split("Found guests:", 1)[1].strip()
+            try:
+                data = ast.literal_eval(payload)
+                latest = tuple(sorted(x["guest_name"] for x in data))
+            except (SyntaxError, ValueError, KeyError, TypeError):
+                continue
+    return latest
+
+
+def last_fingerprint(path: str) -> tuple[str, ...] | None:
+    return fingerprint_intro_guests_after(path, 0)
+
+
+def main() -> int:
+    yaml_rel = sys.argv[1] if len(sys.argv) > 1 else "configs/configv3.yaml"
+    yaml_path = yaml_rel if os.path.isabs(yaml_rel) else os.path.join(REPO, yaml_rel)
+
+    avoid = last_fingerprint(LOG)
+    print("Baseline lineup fingerprint (sorted guest names, multiset):", avoid)
+
+    max_attempts = int(os.environ.get("LLMFH_MAX_GUEST_RETRY", "25"))
+    poll_sec = float(os.environ.get("LLMFH_GUEST_POLL_SEC", "4"))
+    per_attempt_deadline_sec = float(os.environ.get("LLMFH_ATTEMPT_DEADLINE_SEC", str(3 * 3600)))
+
+    for attempt in range(1, max_attempts + 1):
+        lines_before = line_count(LOG)
+        print(f"\n=== Attempt {attempt}/{max_attempts} (log lines before: {lines_before}) ===")
+
+        proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "llm_from_here.showRunner",
+                yaml_path,
+                "--clear-cache",
+            ],
+            cwd=REPO,
+        )
+
+        start = time.monotonic()
+        guest_fp: tuple[str, ...] | None = None
+
+        while proc.poll() is None:
+            if time.monotonic() - start > per_attempt_deadline_sec:
+                print("Attempt deadline exceeded — killing")
+                proc.terminate()
+                try:
+                    proc.wait(timeout=45)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                break
+
+            time.sleep(poll_sec)
+            guest_fp = fingerprint_intro_guests_after(LOG, lines_before)
+            if guest_fp is None:
+                continue
+
+            if avoid is not None and guest_fp == avoid:
+                print("Duplicate lineup vs baseline — terminating run:", guest_fp)
+                proc.terminate()
+                try:
+                    proc.wait(timeout=45)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+                break
+
+            print("New lineup vs baseline — letting run finish:", guest_fp)
+            rc = proc.wait()
+            print(f"ShowRunner finished with exit code {rc}")
+            return rc if rc == 0 else 1
+
+        rc = proc.poll()
+        if rc is not None and rc != 0 and guest_fp is None:
+            print(f"ShowRunner exited early with code {rc} before intro guests appeared")
+
+        if attempt == max_attempts:
+            print("Exceeded max attempts")
+            return 1
+
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/llm_from_here/llm_env.py
+++ b/src/llm_from_here/llm_env.py
@@ -43,9 +43,10 @@ def get_openrouter_chat_model() -> str:
     explicit = os.getenv("OPENROUTER_MODEL", "").strip()
     if explicit:
         return explicit
+    # OpenRouter IDs change; ``deepseek/deepseek-chat`` is the stable chat slug (currently V3-class).
     return (
-        os.getenv("OPENROUTER_MODEL_DEFAULT", "deepseek/deepseek-chat-v2.5").strip()
-        or "deepseek/deepseek-chat-v2.5"
+        os.getenv("OPENROUTER_MODEL_DEFAULT", "deepseek/deepseek-chat").strip()
+        or "deepseek/deepseek-chat"
     )
 
 

--- a/src/llm_from_here/llm_env.py
+++ b/src/llm_from_here/llm_env.py
@@ -43,7 +43,10 @@ def get_openrouter_chat_model() -> str:
     explicit = os.getenv("OPENROUTER_MODEL", "").strip()
     if explicit:
         return explicit
-    return os.getenv("OPENROUTER_MODEL_DEFAULT", "openai/gpt-4o-mini").strip() or "openai/gpt-4o-mini"
+    return (
+        os.getenv("OPENROUTER_MODEL_DEFAULT", "deepseek/deepseek-chat-v2.5").strip()
+        or "deepseek/deepseek-chat-v2.5"
+    )
 
 
 def get_openrouter_tts_model() -> str:

--- a/src/llm_from_here/llm_env.py
+++ b/src/llm_from_here/llm_env.py
@@ -65,11 +65,14 @@ def get_structured_output_mode() -> StructuredOutputMode:
     """
     LLMFH_STRUCTURED_OUTPUT_MODE=native|tool.
     In free mode, default to tool when unset (router variability).
+    DeepSeek via OpenRouter does not support pydantic-ai native structured output; default to tool.
     """
     raw = os.getenv("LLMFH_STRUCTURED_OUTPUT_MODE", "").strip().lower()
     if raw in ("native", "tool"):
         return raw  # type: ignore[return-value]
     if is_openrouter_free_mode():
+        return "tool"
+    if "deepseek" in get_openrouter_chat_model().lower():
         return "tool"
     return "native"
 

--- a/src/llm_from_here/pickleDict.py
+++ b/src/llm_from_here/pickleDict.py
@@ -40,6 +40,9 @@ class PickleDict:
     def __iter__(self):
         return iter(self.data)
 
+    def __contains__(self, key):
+        return key in self.data
+
     def keys(self):
         return self.data.keys()
 

--- a/src/llm_from_here/plugins/audioTimeline.py
+++ b/src/llm_from_here/plugins/audioTimeline.py
@@ -42,9 +42,9 @@ class AudioTimeline:
             return audio
         elif isinstance(audio, str):
             if os.path.isfile(audio):
-                with open(audio, 'rb') as file:
-                    return AudioSegment.from_file(file)
-                #return AudioSegment.from_file(audio)
+                # Pass the path string, not an open handle: pydub/ffmpeg need the
+                # filename for container sniffing; anonymous pipes default badly (e.g. WAV → MP3).
+                return AudioSegment.from_file(audio)
             else:
                 raise ValueError(f"Audio file {audio} does not exist.")
 

--- a/src/llm_from_here/plugins/guestSelection.py
+++ b/src/llm_from_here/plugins/guestSelection.py
@@ -1,11 +1,25 @@
 from llm_from_here.supaQueue import SupaQueue
+from llm_from_here.supaSet import SupaSet
 import llm_from_here.plugins.gpt as gpt
 from llm_from_here.common import is_production_prefix
-import os
+import random
 import numpy as np
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _dedupe_preserve_order(names: list) -> list:
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in names:
+        if not isinstance(item, str):
+            item = str(item)
+        if item in seen:
+            continue
+        seen.add(item)
+        out.append(item)
+    return out
 
 
 class GuestSelection:
@@ -14,11 +28,90 @@ class GuestSelection:
         self.params = params
         self.global_results = global_results
         self.plugin_instance_name = plugin_instance_name
+        autoexpire = params.get("guests_used_autoexpire_days", 365)
+        # Same supasets set_name as Intro (dev_guests_set / guests_set): people
+        # already booked. ``supaqueue`` only tracks pending FIFO rows and deletes them when consumed,
+        # so it never acted as a denylist across refills.
+        self.guests_used = SupaSet(
+            f"{is_production_prefix()}guests_set",
+            autoexpire=autoexpire or None,
+        )
+        self._guest_names_this_run: list[str] = []
+
+    def _sample_used_names(self, limit: int) -> list[str]:
+        els = self.guests_used.elements()
+        pool = els or []
+        if len(pool) <= limit:
+            return list(pool)
+        return random.sample(pool, limit)
 
     def add_to_queue(self, sq, n, prompt):
-        # x = self.chat_app.enforce_list_response_consensus(prompt, n, log_prompt=True)
-        x = self.chat_app.enforce_list_response(prompt, n, log_prompt=True)
-        sq.enqueue(x)
+        def fetch_list(extra_suffix: str = "") -> list[str]:
+            raw = self.chat_app.enforce_list_response(
+                prompt + extra_suffix, n, log_prompt=True
+            )
+            cleaned = _dedupe_preserve_order(raw)
+            fresh = [x for x in cleaned if x not in self.guests_used]
+            skipped = len(cleaned) - len(fresh)
+            if skipped:
+                logger.info(
+                    "Skipping %s names already used on the show when enqueueing to %s",
+                    skipped,
+                    sq.queue_name,
+                )
+            return fresh
+
+        fresh = fetch_list()
+        if not fresh:
+            excluded = self._sample_used_names(60)
+            suffix = ""
+            if excluded:
+                suffix = (
+                    "\n\nThese people have already been booked on the show; "
+                    "do not include them — choose different real names only:\n"
+                    + "\n".join(f"- {x}" for x in excluded)
+                )
+            logger.warning(
+                "LLM returned only repeat guests for %s; retrying with exclusions",
+                sq.queue_name,
+            )
+            fresh = fetch_list(suffix)
+        if not fresh:
+            raise RuntimeError(
+                f"Could not enqueue any fresh guest names for queue {sq.queue_name}; "
+                "try clearing guests_set supaset or widen prompts."
+            )
+        sq.enqueue(fresh)
+
+    def _dequeue_fresh_guests(self, sq, n_needed: int) -> list[str]:
+        """FIFO dequeue, dropping heads that are already in guests_used."""
+        if n_needed <= 0:
+            return []
+        picked: list[str] = []
+        max_ops = max(n_needed * 80, 400)
+        ops = 0
+        while len(picked) < n_needed and ops < max_ops:
+            ops += 1
+            batch = sq.dequeue(1)
+            if not batch:
+                break
+            guest = batch[0]
+            if guest in self.guests_used:
+                logger.info(
+                    "Removing repeat guest %r from queue %s (already used on the show)",
+                    guest,
+                    sq.queue_name,
+                )
+                continue
+            picked.append(guest)
+        if len(picked) < n_needed:
+            logger.warning(
+                "Queue %s: wanted %s fresh guests, got %s (exhausted or too many repeats)",
+                sq.queue_name,
+                n_needed,
+                len(picked),
+            )
+        return picked
 
     def get_params(self, guest_category):
         if not (name := guest_category.get("name")):
@@ -74,7 +167,7 @@ class GuestSelection:
 
             # select select_n elements with probability select_probability
             n = np.random.binomial(select_n, select_probability)
-            selected_guests = supaqs[name].dequeue(n)
+            selected_guests = self._dequeue_fresh_guests(supaqs[name], n)
             
             # repeat n_times with probability n_times_probability
             selected_guests = [
@@ -86,5 +179,17 @@ class GuestSelection:
             for guest in selected_guests:
                 guests.append({"guest_name": guest, "guest_category": name})
 
+        self._guest_names_this_run = [g["guest_name"] for g in guests]
         supaqs["guests"] = guests
         return supaqs
+
+    def finalize(self):
+        """Record this episode's guests so future runs skip them."""
+        names = getattr(self, "_guest_names_this_run", []) or []
+        for name in names:
+            self.guests_used.add(name)
+        self.guests_used.complete_session()
+        logger.info(
+            "GuestSelection finalized guests_used with %s names for this episode",
+            len(names),
+        )

--- a/src/llm_from_here/plugins/showTTS.py
+++ b/src/llm_from_here/plugins/showTTS.py
@@ -4,9 +4,11 @@ import re
 from scipy.io.wavfile import write as write_wav
 from gtts import gTTS
 from pydub import AudioSegment
+from pydub.exceptions import CouldntDecodeError
 from pydub.silence import detect_nonsilent
 
 import os
+import tempfile
 import dotenv
 import logging
 import openai
@@ -21,6 +23,36 @@ from llm_from_here.llm_env import (
 logger = logging.getLogger(__name__)
 
 dotenv.load_dotenv()
+
+
+def _segment_from_openrouter_speech_file(path: str) -> AudioSegment:
+    """Decode binary returned by ``audio.speech.create`` (OpenRouter / OpenAI-compatible)."""
+    size = os.path.getsize(path)
+    if size < 64:
+        raise ValueError(f"Speech payload too small ({size} bytes)")
+    with open(path, "rb") as f:
+        head = f.read(1024)
+    stripped = head.lstrip()
+    if stripped.startswith((b"{", b"[")):
+        snippet = stripped[:1200].decode("utf-8", errors="replace")
+        raise ValueError(
+            "OpenRouter speech endpoint returned JSON/text instead of audio: " + snippet
+        )
+    if head.startswith(b"RIFF"):
+        return AudioSegment.from_file(path, format="wav")
+    if head.startswith(b"ID3") or (
+        len(head) >= 2 and head[0] == 0xFF and (head[1] & 0xE0) == 0xE0
+    ):
+        return AudioSegment.from_file(path, format="mp3")
+    if head.startswith(b"OggS"):
+        return AudioSegment.from_file(path, format="ogg")
+    try:
+        return AudioSegment.from_file(path)
+    except CouldntDecodeError as err:
+        raise ValueError(
+            "Could not decode OpenRouter speech payload "
+            f"(size={size} bytes, hex_prefix={head[:32].hex()})"
+        ) from err
 
 
 def split_sentences(text):
@@ -86,15 +118,17 @@ class ShowTextToSpeech:
     def _speak_gtts(self, text, output_file):
         # fast version that uses google TTS
         tts = gTTS(text=text, lang="en")
-        temp_mp3_file = "temp.mp3"
-        tts.save(temp_mp3_file)
-
-        # Convert the MP3 file to WAV using pydub
-        audio = AudioSegment.from_mp3(temp_mp3_file)
-        audio.export(output_file, format="wav")
-
-        # Remove the temporary MP3 file
-        os.remove(temp_mp3_file)
+        fd, temp_mp3_file = tempfile.mkstemp(suffix=".mp3", prefix="llmfh_gtts_")
+        os.close(fd)
+        try:
+            tts.save(temp_mp3_file)
+            audio = AudioSegment.from_file(temp_mp3_file, format="mp3")
+            audio.export(output_file, format="wav")
+        finally:
+            try:
+                os.remove(temp_mp3_file)
+            except OSError:
+                pass
         logger.info(f"Successfully generated audio file: {output_file}")
         self.audio_file = output_file
 
@@ -106,19 +140,25 @@ class ShowTextToSpeech:
     def _speak_openrouter_tts(self, text, output_file):
         client = self._get_openrouter_client()
 
+        # OpenRouter validates response_format strictly (typically mp3|pcm only).
         response = client.audio.speech.create(
             model=self.tts_model_name,
             voice=self.tts_voice,
             input=text,
+            response_format="mp3",
         )
 
-        # Save the audio to a file
-        response.stream_to_file(output_file + ".mp3")
-
-        # convert to wav
-        audio = AudioSegment.from_mp3(output_file + ".mp3")
-        audio.export(output_file, format="wav")
-        os.remove(output_file + ".mp3")
+        fd, tmp_audio = tempfile.mkstemp(suffix=".mp3", prefix="llmfh_openrouter_tts_")
+        os.close(fd)
+        try:
+            response.stream_to_file(tmp_audio)
+            audio = _segment_from_openrouter_speech_file(tmp_audio)
+            audio.export(output_file, format="wav")
+        finally:
+            try:
+                os.remove(tmp_audio)
+            except OSError:
+                pass
 
         logger.info(f"Successfully generated audio file: {output_file}")
         self.audio_file = output_file

--- a/src/llm_from_here/plugins/supabaseBucketManager.py
+++ b/src/llm_from_here/plugins/supabaseBucketManager.py
@@ -58,7 +58,11 @@ class SupabaseBucketManager:
         
     def add_file(self, source, destination):
         temp_file_path = self.truncate_file(source)
-        res = self.supabase.storage.from_(self.bucket_name).upload(destination, temp_file_path)
+        res = self.supabase.storage.from_(self.bucket_name).upload(
+            destination,
+            temp_file_path,
+            file_options={"upsert": "true"},
+        )
         return res
 
     def get_bucket_size(self):

--- a/src/llm_from_here/plugins/ytfetch.py
+++ b/src/llm_from_here/plugins/ytfetch.py
@@ -2,6 +2,9 @@ import copy
 import glob
 import json
 import os
+import shutil
+import tempfile
+import uuid
 import googleapiclient.discovery
 import googleapiclient.errors
 # import youtube_dl
@@ -22,6 +25,35 @@ from llm_from_here.schemas.llm_outputs import LlmFilterResponse
 
 import logging
 logger = logging.getLogger(__name__)
+
+# Progressive audio first (HTTPS / plain HTTP URL); exclude definite DRM and yt-dlp's
+# "maybe" DRM bucket. Aligns selection with ``FFmpegExtractAudio`` → WAV post-process.
+# Installing Deno helps YouTube n-parameter / JS challenges without cookies (see yt-dlp EJS wiki).
+YOUTUBE_AUDIO_FORMAT_SPEC = (
+    "bestaudio[has_drm!=true][has_drm!=maybe][protocol=https]/"
+    "bestaudio[has_drm!=true][has_drm!=maybe][protocol^=http]/"
+    "bestaudio[has_drm!=true][has_drm!=maybe]/"
+    "bestaudio[has_drm!=true]/"
+    "bestaudio"
+)
+
+
+def _resolved_deno_executable() -> str | None:
+    """
+    Path to the Deno binary for yt-dlp JS/EJS challenges.
+
+    Order: YT_DLP_DENO, ``deno`` on PATH, then the default install.sh location ``~/.deno/bin/deno``.
+    """
+    env_p = os.getenv("YT_DLP_DENO", "").strip()
+    if env_p and os.path.isfile(env_p) and os.access(env_p, os.X_OK):
+        return env_p
+    which = shutil.which("deno")
+    if which and os.access(which, os.X_OK):
+        return which
+    default = os.path.join(os.path.expanduser("~"), ".deno", "bin", "deno")
+    if os.path.isfile(default) and os.access(default, os.X_OK):
+        return default
+    return None
 
 
 def _truthy_env(name: str) -> bool:
@@ -57,6 +89,8 @@ def merge_yt_dlp_env_into(ydl_opts: dict) -> None:
     YT_DLP_SOCKET_TIMEOUT — float seconds for socket_timeout.
     YT_DLP_VERBOSE — if truthy, forces verbose logging and disables quiet/noprogress.
     YT_DLP_DISABLE_FALLBACK — single attempt only (disables automatic no-cookie preset rotation).
+    YT_DLP_FORMAT — full yt-dlp -f string (overrides default progressive-audio chain).
+    YT_DLP_DENO — explicit path to ``deno`` (otherwise PATH / ~/.deno/bin/deno).
     """
     extractor_args: dict = {}
 
@@ -135,6 +169,10 @@ def merge_yt_dlp_env_into(ydl_opts: dict) -> None:
         ydl_opts["noprogress"] = False
         ydl_opts["verbose"] = True
 
+    format_override = os.getenv("YT_DLP_FORMAT", "").strip()
+    if format_override:
+        ydl_opts["format"] = format_override
+
 
 def _explicit_yt_dlp_strategy_env() -> bool:
     """True when the operator set tuning env vars (skip automatic preset rotation)."""
@@ -145,6 +183,7 @@ def _explicit_yt_dlp_strategy_env() -> bool:
         or os.getenv("YT_DLP_EXTRACTOR_ARGS_JSON", "").strip()
         or os.getenv("YT_DLP_COMPAT_OPTIONS", "").strip()
         or os.getenv("YT_DLP_USER_AGENT", "").strip()
+        or os.getenv("YT_DLP_FORMAT", "").strip()
     )
 
 
@@ -196,6 +235,27 @@ def _yt_dlp_fallback_overlays() -> tuple[dict, ...]:
     )
 
 
+def info_has_playable_youtube_audio(info: dict) -> bool:
+    """
+    True when yt-dlp extracted metadata shows at least one audio stream that is
+    not DRM-flagged as definite or ``maybe`` (matches ``YOUTUBE_AUDIO_FORMAT_SPEC`` filters).
+
+    Videos that only expose DRM formats will fail actual downloads; probing avoids that.
+    """
+    formats = info.get("formats")
+    if not formats:
+        return False
+    for fmt in formats:
+        acodec = fmt.get("acodec")
+        if acodec in (None, "none"):
+            continue
+        drm = fmt.get("has_drm")
+        if drm is True or drm == "maybe":
+            continue
+        return True
+    return False
+
+
 def build_yt_dlp_download_attempt_opts(base_opts: dict) -> list[dict]:
     """
     Build yt-dlp option dicts to try in order.
@@ -231,6 +291,85 @@ class YtFetch():
         supaset_name = f'{is_production_prefix()}ytfetch_video_ids_returned'
         self.video_ids_returned = SupaSet(supaset_name,
                                           autoexpire = kwargs.get('video_ids_supaset_autoexpire_days', 180))
+
+    def _build_youtube_audio_ydl_opts(
+        self,
+        output_stem: str,
+        max_duration=None,
+        *,
+        for_download: bool = False,
+    ) -> dict:
+        """Options aligned between probe and ``download_audio`` (same format chain + env)."""
+        ydl_opts = {
+            "format": YOUTUBE_AUDIO_FORMAT_SPEC,
+            "postprocessors": [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "wav",
+                    "preferredquality": "192",
+                }
+            ],
+            "outtmpl": output_stem,
+            "nocheckcertificate": True,
+            "remote_components": {"ejs:github"},
+            "quiet": True,
+            "noprogress": True,
+            "postprocessor_args": ["-ac", "2"],
+        }
+        deno_exe = _resolved_deno_executable()
+        if deno_exe:
+            ydl_opts["js_runtimes"] = {"deno": {"path": deno_exe}}
+        if for_download:
+            # HEAD/quick fragment test on the chosen format only (too slow for search probes).
+            ydl_opts["check_formats"] = "selected"
+        if max_duration:
+            logger.info(f"Setting max duration to {max_duration}")
+            ydl_opts["postprocessor_args"] = [
+                *ydl_opts["postprocessor_args"],
+                "-t",
+                str(max_duration),
+            ]
+        return ydl_opts
+
+    def youtube_video_has_extractable_audio(self, video_url: str, max_duration=None) -> bool:
+        """
+        Run yt-dlp metadata extraction (no download) and check that at least one
+        non-DRM audio format exists, using the same env-driven presets as ``download_audio``.
+        """
+        probe_stem = os.path.join(
+            tempfile.gettempdir(),
+            f"llmfh_yt_probe_{uuid.uuid4().hex}",
+        )
+        ydl_opts = self._build_youtube_audio_ydl_opts(probe_stem, max_duration)
+        merge_yt_dlp_env_into(ydl_opts)
+        attempts = build_yt_dlp_download_attempt_opts(ydl_opts)
+        last_err: BaseException | None = None
+        for idx, attempt_opts in enumerate(attempts):
+            opts = copy.deepcopy(attempt_opts)
+            opts["quiet"] = True
+            opts["noprogress"] = True
+            try:
+                with youtube_dl.YoutubeDL(opts) as ydl:
+                    info = ydl.extract_info(video_url, download=False)
+                if info_has_playable_youtube_audio(info):
+                    return True
+            except (DownloadError, ExtractorError, YoutubeDLError, OSError) as err:
+                last_err = err
+                logger.debug(
+                    "yt-dlp DRM/audio probe attempt %s/%s failed: %s",
+                    idx + 1,
+                    len(attempts),
+                    err,
+                )
+            finally:
+                _scrub_partial_downloads(probe_stem)
+        if last_err:
+            logger.info(
+                "yt-dlp probe could not confirm playable audio for %s: %s",
+                video_url,
+                last_err,
+            )
+        return False
 
     @retry((googleapiclient.errors.HttpError,), tries=3, delay=2)
     def _execute_with_retry(self, request, operation_name):
@@ -298,32 +437,11 @@ class YtFetch():
         
     
     def download_audio(self, video_url, output_file, max_duration=None):
-        #strip .wav from output_file
         output_file = output_file.replace(".wav", "")
-
-        ydl_opts = {
-            'format': 'bestaudio',
-            'postprocessors': [{
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'wav',
-                'preferredquality': '192',
-            }],
-            'outtmpl': output_file,
-            'nocheckcertificate': True,
-            # Fetch signed hashes/player JS helpers from GitHub when needed (CI-friendly).
-            'remote_components': {'ejs:github'},
-            'quiet': True,
-            'noprogress': True,
-            'postprocessor_args': ['-ac', '2'], #force 2-channels
-            # 'verbose': True
-        }
+        ydl_opts = self._build_youtube_audio_ydl_opts(
+            output_file, max_duration, for_download=True
+        )
         merge_yt_dlp_env_into(ydl_opts)
-        if max_duration:
-            logger.info(f"Setting max duration to {max_duration}")
-            #def download_ranges_callback(info_dict, ydl):
-            #    return [ {'start_time': 0, 'end_time': max_duration, 'title': 'Section 1', 'index': 1}]
-            #ydl_opts['download_ranges'] = download_ranges_callback
-            ydl_opts['postprocessor_args'].extend(['-t', str(max_duration)])
 
         attempts = build_yt_dlp_download_attempt_opts(ydl_opts)
         last_err: BaseException | None = None
@@ -430,8 +548,7 @@ class YtFetch():
             channel_title = video['channel_title']
             duration_seconds = video['duration'] if use_music else None
             
-            # Check if this video has already been returned
-            if not self.video_ids_returned.add(video_id):
+            if video_id in self.video_ids_returned:
                 logger.info(f"Video {video_id} already returned. Skipping.")
                 continue
 
@@ -473,13 +590,27 @@ class YtFetch():
             ):
                 logger.info(f"Video https://www.youtube.com/watch?v={video_id} removed by llm filter. Skipping.")
                 continue
-            
-            # if everything passes, return the video
+
+            video_url = f"https://www.youtube.com/watch?v={video_id}"
+            if not self.youtube_video_has_extractable_audio(
+                video_url, truncation_duration_sec
+            ):
+                logger.info(
+                    "Skipping video %s (%r): yt-dlp metadata shows no non-DRM extractable audio",
+                    video_id,
+                    title,
+                )
+                continue
+
+            if not self.video_ids_returned.add(video_id):
+                logger.info(f"Video {video_id} already returned (could not reserve). Skipping.")
+                continue
+
             return {
                         'video_id': video_id,
                         'title': title,
                         'channel_title': channel_title,
-                        'video_url': f"https://www.youtube.com/watch?v={video_id}",
+                        'video_url': video_url,
                         'truncation_duration_sec': truncation_duration_sec
                     }
 
@@ -573,6 +704,15 @@ class YtFetch():
                     'video_url': random_video_url
                 }
                 logger.info(f"Video Title: {video_details['title']}")
+
+                if not self.youtube_video_has_extractable_audio(random_video_url):
+                    logger.info(
+                        "Skipping DRM/non-downloadable playlist pick: %s",
+                        random_video_url,
+                    )
+                    raise ExtractorError(
+                        "No extractable non-DRM audio for playlist candidate",
+                    )
 
                 # Download audio
                 if not output_file:

--- a/src/llm_from_here/plugins/ytfetch.py
+++ b/src/llm_from_here/plugins/ytfetch.py
@@ -300,6 +300,7 @@ class YtFetch():
         for_download: bool = False,
     ) -> dict:
         """Options aligned between probe and ``download_audio`` (same format chain + env)."""
+        ffmpeg_pp_args = ["-ac", "2"]
         ydl_opts = {
             "format": YOUTUBE_AUDIO_FORMAT_SPEC,
             "postprocessors": [
@@ -314,7 +315,7 @@ class YtFetch():
             "remote_components": {"ejs:github"},
             "quiet": True,
             "noprogress": True,
-            "postprocessor_args": ["-ac", "2"],
+            "postprocessor_args": ffmpeg_pp_args,
         }
         deno_exe = _resolved_deno_executable()
         if deno_exe:
@@ -324,11 +325,7 @@ class YtFetch():
             ydl_opts["check_formats"] = "selected"
         if max_duration:
             logger.info(f"Setting max duration to {max_duration}")
-            ydl_opts["postprocessor_args"] = [
-                *ydl_opts["postprocessor_args"],
-                "-t",
-                str(max_duration),
-            ]
+            ffmpeg_pp_args.extend(["-t", str(max_duration)])
         return ydl_opts
 
     def youtube_video_has_extractable_audio(self, video_url: str, max_duration=None) -> bool:

--- a/src/llm_from_here/showRunner.py
+++ b/src/llm_from_here/showRunner.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import logging
 import os
 import sys
@@ -77,11 +78,34 @@ def load_yaml(yaml_file):
         data = yaml.load(file, Loader=yaml.FullLoader)
     return data
 
+
+def plugin_cache_entry_hash(entry, global_results):
+    """
+    Stable cache key for a plugin YAML entry.
+
+    When ``params.guests_parameter`` is set (e.g. introFromGuestlist), the key
+    includes a fingerprint of that global_results value so a fresh guest
+    dequeue invalidates cached intro/script output without requiring --clear-cache.
+    """
+    base = hashlib.md5(str(entry).encode()).hexdigest()
+    guests_parameter = entry.get("params", {}).get("guests_parameter")
+    if not guests_parameter:
+        return base
+    dep = global_results.get(guests_parameter)
+    if dep is None:
+        return base
+    blob = json.dumps(dep, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.md5(f"{base}:{guests_parameter}:{blob}".encode()).hexdigest()
+
+
 def execute_plugins(yaml_file, clear_cache=False, outputs_dir=None):
     global global_results
     if clear_cache:
         plugin_cache.clear()
-        logger.info("Cache cleared.")
+        logger.info(
+            "Plugin result cache cleared (%s).",
+            os.path.join(cache_dir, "cache.pickle"),
+        )
 
     data = load_yaml(yaml_file)
 
@@ -121,8 +145,7 @@ def execute_plugins(yaml_file, clear_cache=False, outputs_dir=None):
             _log_context(run_id, plugin_name, "skip", "only_in_prod plugin skipped")
             continue
 
-        # Generate hash of the plugin entry
-        entry_hash = hashlib.md5(str(entry).encode()).hexdigest()
+        entry_hash = plugin_cache_entry_hash(entry, global_results)
 
         # Check if cache is enabled and entry is in cache
         from_cache = False

--- a/tests/test_audio_timeline_validate.py
+++ b/tests/test_audio_timeline_validate.py
@@ -1,0 +1,15 @@
+"""Regression: timeline loads files by path so pydub/ffmpeg can sniff container."""
+
+from pydub import AudioSegment
+
+from llm_from_here.plugins.audioTimeline import AudioTimeline
+
+
+def test_validate_audio_loads_wav_by_path(tmp_path):
+    wav_path = tmp_path / "clip.wav"
+    AudioSegment.silent(duration=50).export(wav_path, format="wav")
+
+    tl = AudioTimeline()
+    seg = tl._validate_audio(str(wav_path))
+    assert isinstance(seg, AudioSegment)
+    assert len(seg) == 50

--- a/tests/test_deno_resolution.py
+++ b/tests/test_deno_resolution.py
@@ -1,0 +1,49 @@
+"""Tests for Deno binary resolution used by yt-dlp."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from llm_from_here.plugins.ytfetch import _resolved_deno_executable
+
+
+@pytest.fixture
+def fake_deno(tmp_path):
+    p = tmp_path / "deno"
+    p.write_text("#!/bin/sh\necho deno\n")
+    p.chmod(0o755)
+    return p
+
+
+def test_resolved_deno_prefers_yt_dlp_deno(monkeypatch, fake_deno):
+    monkeypatch.setenv("YT_DLP_DENO", str(fake_deno))
+    monkeypatch.delenv("PATH", raising=False)
+    assert _resolved_deno_executable() == str(fake_deno)
+
+
+def test_resolved_deno_which(monkeypatch, fake_deno):
+    monkeypatch.delenv("YT_DLP_DENO", raising=False)
+    monkeypatch.setenv("PATH", str(fake_deno.parent))
+    assert _resolved_deno_executable() == str(fake_deno)
+
+
+def test_resolved_deno_default_home(monkeypatch, fake_deno, tmp_path):
+    monkeypatch.delenv("YT_DLP_DENO", raising=False)
+    monkeypatch.setenv("PATH", "")
+    home = tmp_path / "h"
+    bin_dir = home / ".deno" / "bin"
+    bin_dir.mkdir(parents=True)
+    target = bin_dir / "deno"
+    target.write_bytes(fake_deno.read_bytes())
+    target.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    assert _resolved_deno_executable() == str(target)
+
+
+def test_resolved_deno_none_when_missing(monkeypatch, tmp_path):
+    monkeypatch.delenv("YT_DLP_DENO", raising=False)
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _resolved_deno_executable() is None

--- a/tests/test_guestSelection.py
+++ b/tests/test_guestSelection.py
@@ -1,8 +1,18 @@
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from llm_from_here.supaQueue import SupaQueue
 import llm_from_here.plugins.gpt as gpt
-from llm_from_here.plugins.guestSelection import GuestSelection 
+from llm_from_here.plugins.guestSelection import GuestSelection
+
+
+class _OfflineGuestsUsed:
+    """Stand-in for SupaSet when SUPABASE_* env is unset (e.g. CI unit tests)."""
+
+    def __contains__(self, item) -> bool:
+        return False
+
+    def elements(self):
+        return []
 
 class TestGuestSelection:
     @pytest.fixture
@@ -18,7 +28,16 @@ class TestGuestSelection:
         params = {"guest_categories": [{"name": "test", "prompt": "Hello"}]}
         global_results = []
         plugin_instance_name = 'test_instance'
-        return GuestSelection(params, global_results, plugin_instance_name, chat_app=mock_chat_app)
+        with patch(
+            'llm_from_here.plugins.guestSelection.SupaSet',
+            return_value=_OfflineGuestsUsed(),
+        ):
+            return GuestSelection(
+                params,
+                global_results,
+                plugin_instance_name,
+                chat_app=mock_chat_app,
+            )
 
     def test_add_to_queue(self, guest_selection, mock_supa_queue, mock_chat_app):
         n = 1

--- a/tests/test_guest_selection_dedupe.py
+++ b/tests/test_guest_selection_dedupe.py
@@ -1,0 +1,11 @@
+import pytest
+
+from llm_from_here.plugins.guestSelection import _dedupe_preserve_order
+
+
+def test_dedupe_preserve_order_strings():
+    assert _dedupe_preserve_order(["a", "b", "a", "c"]) == ["a", "b", "c"]
+
+
+def test_dedupe_preserve_order_coerces_non_string():
+    assert _dedupe_preserve_order(["x", 1, "x"]) == ["x", "1"]

--- a/tests/test_showRunner.py
+++ b/tests/test_showRunner.py
@@ -1,4 +1,4 @@
-
+import hashlib
 import unittest
 import tempfile
 from unittest.mock import patch, mock_open, call, MagicMock
@@ -6,6 +6,28 @@ import unittest.mock as mock
 import llm_from_here.showRunner as showRunner
 
 class TestShowRunner(unittest.TestCase):
+
+    def test_plugin_cache_entry_hash_stable_without_guests_parameter(self):
+        entry = {"plugin": "p", "class": "C", "cache": True, "params": {}}
+        gr = {"guest_selection_guests": [{"guest_name": "A"}]}
+        h1 = showRunner.plugin_cache_entry_hash(entry, gr)
+        h2 = showRunner.plugin_cache_entry_hash(entry, gr)
+        self.assertEqual(h1, h2)
+        self.assertEqual(h1, hashlib.md5(str(entry).encode()).hexdigest())
+
+    def test_plugin_cache_entry_hash_changes_with_guest_list(self):
+        entry = {
+            "plugin": "introFromGuestlist",
+            "class": "IntroFromGuestlist",
+            "cache": True,
+            "params": {"guests_parameter": "guest_selection_guests"},
+        }
+        gr_a = {"guest_selection_guests": [{"guest_name": "Pat", "guest_category": "music"}]}
+        gr_b = {"guest_selection_guests": [{"guest_name": "Sam", "guest_category": "music"}]}
+        self.assertNotEqual(
+            showRunner.plugin_cache_entry_hash(entry, gr_a),
+            showRunner.plugin_cache_entry_hash(entry, gr_b),
+        )
 
     @patch("os.path.isdir")
     @patch("os.listdir")

--- a/tests/test_youtube_drm_probe.py
+++ b/tests/test_youtube_drm_probe.py
@@ -1,0 +1,53 @@
+"""Unit tests for YouTube DRM / extractability probing (ytfetch metadata)."""
+
+from llm_from_here.plugins.ytfetch import info_has_playable_youtube_audio
+
+
+def test_info_has_playable_youtube_audio_empty():
+    assert info_has_playable_youtube_audio({}) is False
+
+
+def test_info_has_playable_youtube_audio_no_formats_key():
+    assert info_has_playable_youtube_audio({"title": "x"}) is False
+
+
+def test_info_has_playable_youtube_audio_drm_only():
+    info = {
+        "formats": [
+            {"acodec": "mp4a.40.2", "has_drm": True},
+            {"acodec": "opus", "has_drm": True},
+        ]
+    }
+    assert info_has_playable_youtube_audio(info) is False
+
+
+def test_info_has_playable_youtube_audio_clean_audio():
+    info = {"formats": [{"acodec": "opus", "has_drm": False}]}
+    assert info_has_playable_youtube_audio(info) is True
+
+
+def test_info_has_playable_youtube_audio_missing_has_drm_treated_ok():
+    """Unset ``has_drm`` means not explicitly flagged DRM-only."""
+    info = {"formats": [{"acodec": "opus"}]}
+    assert info_has_playable_youtube_audio(info) is True
+
+
+def test_info_has_playable_youtube_audio_maybedrm_rejected():
+    """Match yt-dlp ``has_drm == \"maybe\"`` bucket (ambiguous DRM)."""
+    info = {"formats": [{"acodec": "opus", "has_drm": "maybe"}]}
+    assert info_has_playable_youtube_audio(info) is False
+
+
+def test_info_has_playable_youtube_audio_video_only_streams_skipped():
+    info = {"formats": [{"acodec": "none", "vcodec": "avc1"}]}
+    assert info_has_playable_youtube_audio(info) is False
+
+
+def test_info_has_playable_youtube_audio_mixed_drm_and_clean():
+    info = {
+        "formats": [
+            {"acodec": "opus", "has_drm": True},
+            {"acodec": "mp4a.40.2"},
+        ]
+    }
+    assert info_has_playable_youtube_audio(info) is True

--- a/tests/test_yt_dlp_env_opts.py
+++ b/tests/test_yt_dlp_env_opts.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from llm_from_here.plugins.ytfetch import (
+    YOUTUBE_AUDIO_FORMAT_SPEC,
     build_yt_dlp_download_attempt_opts,
     merge_yt_dlp_env_into,
     _yt_dlp_fallback_overlays,
@@ -22,6 +23,7 @@ _YT_DLP_ENV_KEYS = (
     "YT_DLP_SOCKET_TIMEOUT",
     "YT_DLP_VERBOSE",
     "YT_DLP_DISABLE_FALLBACK",
+    "YT_DLP_FORMAT",
 )
 
 
@@ -61,6 +63,13 @@ def test_compat_opts(monkeypatch):
     opts: dict = {}
     merge_yt_dlp_env_into(opts)
     assert opts["compat_opts"] == {"2025", "2024"}
+
+
+def test_format_override(monkeypatch):
+    monkeypatch.setenv("YT_DLP_FORMAT", "bestaudio/worstaudio")
+    opts: dict = {"format": YOUTUBE_AUDIO_FORMAT_SPEC}
+    merge_yt_dlp_env_into(opts)
+    assert opts["format"] == "bestaudio/worstaudio"
 
 
 def test_verbose(monkeypatch):
@@ -113,7 +122,15 @@ def test_build_attempts_fallback_chain_length(monkeypatch):
 
 
 def test_build_attempts_fallback_keeps_base_keys(monkeypatch):
-    base = {"quiet": True, "format": "bestaudio"}
+    base = {"quiet": True, "format": YOUTUBE_AUDIO_FORMAT_SPEC}
     attempts = build_yt_dlp_download_attempt_opts(base)
     assert attempts[-1]["quiet"] is True
-    assert attempts[-1]["format"] == "bestaudio"
+    assert attempts[-1]["format"] == YOUTUBE_AUDIO_FORMAT_SPEC
+
+
+def test_build_attempts_single_when_explicit_format(monkeypatch):
+    monkeypatch.setenv("YT_DLP_FORMAT", "bestaudio")
+    base = {"quiet": True}
+    merge_yt_dlp_env_into(base)
+    attempts = build_yt_dlp_download_attempt_opts(base)
+    assert len(attempts) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -467,6 +467,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -792,6 +801,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -902,6 +920,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
     { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
     { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
     { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
     { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
@@ -1464,6 +1483,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -2039,6 +2067,7 @@ dependencies = [
 dev = [
     { name = "mypy" },
     { name = "pip-audit" },
+    { name = "pre-commit" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -2069,6 +2098,7 @@ requires-dist = [
     { name = "pathvalidate" },
     { name = "pip-audit", marker = "extra == 'dev'" },
     { name = "plotly" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "pydantic-ai", specifier = ">=1.88.0" },
     { name = "pydub" },
     { name = "pyright", marker = "extra == 'dev'" },
@@ -3177,6 +3207,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -3809,6 +3855,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e0/cc5a8653e9a24f6cf84768f05064aa8ed5a83dcefd5e2a043db14a1c5f44/python_discovery-1.3.0.tar.gz", hash = "sha256:d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0", size = 63925, upload-time = "2026-05-05T14:38:39.769Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/d4/24d543ab8b8158b7f5a97113c831205f5c900c92c8762b1e7f44b7ea0405/python_discovery-1.3.0-py3-none-any.whl", hash = "sha256:441d9ced3dfce36e113beb35ca302c71c7ef06f3c0f9c227a0b9bb3bd49b9e9f", size = 33124, upload-time = "2026-05-05T14:38:38.539Z" },
 ]
 
 [[package]]
@@ -4930,6 +4989,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/0d/915c02c94d207b85580eb09bffab54438a709e7288524094fe781da526c2/virtualenv-21.3.1.tar.gz", hash = "sha256:c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b", size = 7613791, upload-time = "2026-05-05T01:34:31.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/4f/f71e641e504111a5a74e3a20bc52d01bd86788b22699dd3fee1c63253cf6/virtualenv-21.3.1-py3-none-any.whl", hash = "sha256:d1a71cf58f2f9228fff23a1f6ec15d39785c6b32e03658d104974247145edd35", size = 7594539, upload-time = "2026-05-05T01:34:28.98Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -709,25 +709,35 @@ wheels = [
 
 [[package]]
 name = "curl-cffi"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "cffi" },
+    { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/c9/0067d9a25ed4592b022d4558157fcdb6e123516083700786d38091688767/curl_cffi-0.14.0.tar.gz", hash = "sha256:5ffbc82e59f05008ec08ea432f0e535418823cda44178ee518906a54f27a5f0f", size = 162633, upload-time = "2025-12-16T03:25:07.931Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/f0/0f21e9688eaac85e705537b3a87a5588d0cefb2f09d83e83e0e8be93aa99/curl_cffi-0.14.0-cp39-abi3-macosx_14_0_arm64.whl", hash = "sha256:e35e89c6a69872f9749d6d5fda642ed4fc159619329e99d577d0104c9aad5893", size = 3087277, upload-time = "2025-12-16T03:24:49.607Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/a3/0419bd48fce5b145cb6a2344c6ac17efa588f5b0061f212c88e0723da026/curl_cffi-0.14.0-cp39-abi3-macosx_15_0_x86_64.whl", hash = "sha256:5945478cd28ad7dfb5c54473bcfb6743ee1d66554d57951fdf8fc0e7d8cf4e45", size = 5804650, upload-time = "2025-12-16T03:24:51.518Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/07/a238dd062b7841b8caa2fa8a359eb997147ff3161288f0dd46654d898b4d/curl_cffi-0.14.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c42e8fa3c667db9ccd2e696ee47adcd3cd5b0838d7282f3fc45f6c0ef3cfdfa7", size = 8231918, upload-time = "2025-12-16T03:24:52.862Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/d2/ce907c9b37b5caf76ac08db40cc4ce3d9f94c5500db68a195af3513eacbc/curl_cffi-0.14.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:060fe2c99c41d3cb7f894de318ddf4b0301b08dca70453d769bd4e74b36b8483", size = 8654624, upload-time = "2025-12-16T03:24:54.579Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/ae/6256995b18c75e6ef76b30753a5109e786813aa79088b27c8eabb1ef85c9/curl_cffi-0.14.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b158c41a25388690dd0d40b5bc38d1e0f512135f17fdb8029868cbc1993d2e5b", size = 8010654, upload-time = "2025-12-16T03:24:56.507Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/10/ff64249e516b103cb762e0a9dca3ee0f04cf25e2a1d5d9838e0f1273d071/curl_cffi-0.14.0-cp39-abi3-manylinux_2_28_i686.whl", hash = "sha256:1439fbef3500fb723333c826adf0efb0e2e5065a703fb5eccce637a2250db34a", size = 7781969, upload-time = "2025-12-16T03:24:57.885Z" },
-    { url = "https://files.pythonhosted.org/packages/51/76/d6f7bb76c2d12811aa7ff16f5e17b678abdd1b357b9a8ac56310ceccabd5/curl_cffi-0.14.0-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7176f2c2d22b542e3cf261072a81deb018cfa7688930f95dddef215caddb469", size = 7969133, upload-time = "2025-12-16T03:24:59.261Z" },
-    { url = "https://files.pythonhosted.org/packages/23/7c/cca39c0ed4e1772613d3cba13091c0e9d3b89365e84b9bf9838259a3cd8f/curl_cffi-0.14.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:03f21ade2d72978c2bb8670e9b6de5260e2755092b02d94b70b906813662998d", size = 9080167, upload-time = "2025-12-16T03:25:00.946Z" },
-    { url = "https://files.pythonhosted.org/packages/75/03/a942d7119d3e8911094d157598ae0169b1c6ca1bd3f27d7991b279bcc45b/curl_cffi-0.14.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:58ebf02de64ee5c95613209ddacb014c2d2f86298d7080c0a1c12ed876ee0690", size = 9520464, upload-time = "2025-12-16T03:25:02.922Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/77/78900e9b0833066d2274bda75cba426fdb4cef7fbf6a4f6a6ca447607bec/curl_cffi-0.14.0-cp39-abi3-win_amd64.whl", hash = "sha256:6e503f9a103f6ae7acfb3890c843b53ec030785a22ae7682a22cc43afb94123e", size = 1677416, upload-time = "2025-12-16T03:25:04.902Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/7c/d2ba86b0b3e1e2830bd94163d047de122c69a8df03c5c7c36326c456ad82/curl_cffi-0.14.0-cp39-abi3-win_arm64.whl", hash = "sha256:2eed50a969201605c863c4c31269dfc3e0da52916086ac54553cfa353022425c", size = 1425067, upload-time = "2025-12-16T03:25:06.454Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
 ]
 
 [[package]]
@@ -2079,7 +2089,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "appdirs" },
-    { name = "curl-cffi", specifier = ">=0.10,<0.15" },
+    { name = "curl-cffi", specifier = ">=0.15,<0.16" },
     { name = "feedparser" },
     { name = "freesound-python", git = "https://github.com/MTG/freesound-python.git" },
     { name = "fuzzywuzzy" },


### PR DESCRIPTION
## Summary
Validated locally with a full dev ShowRunner run (fresh lineup vs repeat Lumineers era).

### Guest pipeline
- **guest_selection** no longer relies only on `supaqueue` FIFO (rows are deleted on finalize; LLM refills could repeat the same celebrities).
- **GuestSelection** filters enqueues and skips stale FIFO heads against Supabase **`guests_set`** (same set as legacy `Intro`), and **finalize** records this episode’s names.
- **configv3**: turn off plugin disk cache for guest_selection so each run dequeues; intro cache key includes `guest_selection_guests` fingerprint so script stays aligned.
- Helper **`scripts/run_until_new_guests.py`** optional retry loop vs prior log fingerprint.

### Playback / fetch / TTS
- **ytfetch**: Deno resolution, DRM/format probing and env wiring; tests.
- **audioTimeline**: open WAV by path for pydub validation (fixes ffmpeg mis-decode).
- **showTTS**: OpenRouter speech as mp3 + sniff/error handling.
- **preflight_env** `--require-deno`; README / `.env.example` updates.

### Misc
- **PickleDict**: explicit `__contains__`; clearer `--clear-cache` logging path.

## Testing
- `pytest` for new/updated tests (guest dedupe, showRunner hash, ytfetch env, deno, drm probe, audio timeline).

Made with [Cursor](https://cursor.com)